### PR TITLE
Use gstreamer1.0 instead of gstreamer0.1

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 rock_library(camera_usb
     SOURCES cam_config.cpp cam_gst.cpp cam_usb.cpp
     HEADERS cam_config.h cam_gst.h cam_usb.h omap_v4l2.h helpers.h
-    DEPS_PKGCONFIG base-lib camera_interface 
-    DEPS_PKGCONFIG gstreamer-0.10 gstreamer-plugins-base-0.10 gstreamer-app-0.10
+    DEPS_PKGCONFIG base-lib camera_interface
+    DEPS_PKGCONFIG gstreamer-1.0 gstreamer-plugins-base-1.0 gstreamer-app-1.0
 )
 target_link_libraries(camera_usb pthread)
 

--- a/src/cam_gst.h
+++ b/src/cam_gst.h
@@ -208,12 +208,12 @@ class CamGst {
     /**
      * Calls the method 'callbackNewBuffer()' of the passed CamGst object.
      */
-    static void callbackNewBufferStatic(GstElement* object, CamGst* cam_gst_p); 
+    static void callbackNewBufferStatic(GstAppSink *object, CamGst* cam_gst_p);
     
     /**
      * Copies the received image to 'mBuffer'.
      */
-    void callbackNewBuffer(GstElement* object, CamGst* cam_gst_p); 
+    void callbackNewBuffer(GstAppSink* object, CamGst* cam_gst_p);
 
     /**
      * Print element factories for debugging purposes
@@ -232,6 +232,7 @@ class CamGst {
     pthread_mutex_t mMutexBuffer;
     GstBuffer* mBuffer;
     uint32_t mBufferSize;
+    GstSample* mSample;
     bool mNewBuffer;
 
     GstElement* mSource; // Used to request the fd.


### PR DESCRIPTION
as discussed in #5 gstreamer0.1 is outdated. This PR ports camera_usb to use gstreamer1.0 instead.

**Status**: 
* I think it works, but it's untested with `orogen/camera_usb`, yet. 
* There is a bug when using the test program `camera_usb_control`. the cam is not properly closed after requesting frames using gstreamer. Construction of the pipeline fails, when it's tried to request images for a second time.